### PR TITLE
Add unsubscribe

### DIFF
--- a/benches/nkv_bench.rs
+++ b/benches/nkv_bench.rs
@@ -228,6 +228,7 @@ fn bench_server(c: &mut Criterion) {
                     let (del_resp_tx, mut del_resp_rx) = mpsc::channel(1);
                     let _ = del_tx.send(BaseMsg {
                         key: "key1".to_string(),
+                        uuid: "0".to_string(),
                         resp_tx: del_resp_tx,
                     });
                     let result = del_resp_rx.recv().await.unwrap();

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -88,6 +88,16 @@ async fn main() {
                         println!("SUBSCRIBE requires a key");
                     }
                 }
+                "UNSUBSCRIBE" => {
+                    if let Some(key) = parts.get(1) {
+                        let start = Instant::now();
+                        let resp = client.unsubscribe(key.to_string()).await.unwrap();
+                        let elapsed = start.elapsed();
+                        println!("Request took: {:.2?}\n{}", elapsed, resp);
+                    } else {
+                        println!("SUBSCRIBE requires a key");
+                    }
+                }
                 "QUIT" => {
                     break;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::fmt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::TcpStream;
-use tokio::sync::{mpsc, watch};
 use uuid::Uuid;
 
 #[derive(Debug)]

--- a/src/nkv.rs
+++ b/src/nkv.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use crate::notifier::{Message, Notifier, NotifierError, WriteStream};
+use crate::notifier::{Notifier, NotifierError, WriteStream};
 use crate::persist_value::PersistValue;
 use crate::trie::{Trie, TrieNode};
 use std::fmt;

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::TcpStream;
-use tokio::sync::{mpsc, watch, Mutex};
+use tokio::sync::{watch, Mutex};
 use tokio::time::{sleep, Duration};
 
 #[derive(Debug)]

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -113,16 +113,14 @@ impl<T> StateBuf<T> {
 #[derive(Debug)]
 pub struct Notifier {
     clients: Arc<Mutex<HashMap<SocketAddr, WriteStream>>>,
+    // use a buffer to guarantee latest state on consumers
+    // for detailed information see DESIGN_DECISIONS.md
     msg_buf: Arc<Mutex<StateBuf<Message>>>,
     notifier: watch::Sender<bool>,
 }
 
 impl Notifier {
     pub fn new() -> Self {
-        // use a buffer to guarantee latest state on consumers
-        // for detailed information see DESIGN_DECISIONS.md
-        // let (msg_tx, mut msg_rx) = mpsc::unbounded_channel::<Message>();
-
         let clients = Arc::new(Mutex::new(HashMap::new()));
         let msg_buf = Arc::new(Mutex::new(StateBuf::new()));
         let (tx, mut rx) = watch::channel(false);

--- a/src/request_msg.rs
+++ b/src/request_msg.rs
@@ -11,6 +11,7 @@ use std::fmt;
 pub struct BaseMessage {
     pub id: String,
     pub key: String,
+    pub client_uuid: String,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -27,6 +28,7 @@ pub enum ServerRequest {
     Get(BaseMessage),
     Delete(BaseMessage),
     Subscribe(BaseMessage),
+    Unsubscribe(BaseMessage),
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]

--- a/src/srv.rs
+++ b/src/srv.rs
@@ -90,12 +90,12 @@ impl Server {
                     Some(req) = get_rx.recv() => {
                         let vals = nkv.get(&req.key);
                         if vals.len() > 0 {
-                            req.resp_tx.send(NkvGetResp {
+                            let _ = req.resp_tx.send(NkvGetResp {
                                 value: vals,
                                 err: nkv::NotifyKeyValueError::NoError
                             }).await;
                         } else {
-                            req.resp_tx.send(NkvGetResp {
+                            let _ = req.resp_tx.send(NkvGetResp {
                                 value: Vec::new(),
                                 err: nkv::NotifyKeyValueError::NotFound
                             }).await;


### PR DESCRIPTION
With that client can unsubscribe from updates of a value.
Main change in API concerns the fact that now we store subscriptions
not based on SocketAddr, but on client uuid, that a) abstracts us from
TCP as a transport layer and b) gives easier flexibility to trace clients

Also this commit introduces sending Hello message to a client when it
subscribes to a value, it removes any need for sleeps in any tests making
async programming correct way