### PR TITLE
Add nightly build to GitHub packages during main build

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -19,3 +19,20 @@ jobs:
 
       - name: build and test
         uses: ./.github/actions/build-and-test
+
+  publish-nighltly:
+    runs-on: ubuntu-latest
+    needs: bulid-and-test
+   
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Packages Docker registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build Docker image
+        run: docker build -t ghcr.io/${{ github.repository_owner }}/nkv-nightly:latest .
+
+      - name: Push Docker image
+        run: docker push ghcr.io/${{ github.repository_owner }}/nkv-nightly:latest


### PR DESCRIPTION
Want to merge and check if everything passes, then I'll add dockerhub and then I'll create a release v0.1.0 (to be in sync with rust cargo package I guess it's important). After that we're good to go trying to integrate that side-by-side with EVE, exciting times :) 

Whenever I'll have time I'll rework the benchmarks a bit, so that they'll be faster and I'll try to investigate what's wrong with the results, but that's not important right now 