### PR TITLE
Integrate nkv_spec using capnproto to (de-)serialize messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,20 +40,9 @@ checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
-
-[[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "autocfg"
@@ -77,6 +66,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,9 +85,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cast"
@@ -245,21 +240,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "futures"
@@ -269,7 +252,6 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -278,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -288,66 +270,39 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -390,27 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
-name = "http"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-serde"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
-dependencies = [
- "http",
- "serde",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -505,16 +439,11 @@ name = "nkv"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
+ "base64",
  "criterion",
- "futures",
- "http",
- "http-serde",
- "serde",
- "serde_json",
- "tempdir",
  "tempfile",
  "tokio",
+ "tokio-util",
  "uuid",
 ]
 
@@ -630,34 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,15 +576,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -725,15 +617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,9 +624,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags",
  "errno",
@@ -815,15 +698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,20 +725,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -910,6 +774,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1009,22 +886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,12 +893,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.86"
-async-trait = "0.1.83"
-futures = "0.3.30"
-http = "1.1.0"
-http-serde = "2.1.1"
-serde = { version = "1.0.204", features = ["derive"] }
-serde_json = "1.0.121"
-tempdir = "0.3"
 tempfile = "3.10.1"
 tokio = { version = "1.39.1", features = ["full"] }
 uuid = { version = "1.4", features = ["v4"] }
+tokio-util = { version = "0.7.12", features = ["codec"] }
+base64 = "0.22.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio", "html_reports"] }
+anyhow = "1.0.86"
 
 [lib]
 name = "nkv"
@@ -37,6 +32,6 @@ harness = false
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary
-opt-level = "z"  # Optimize for size.
+# opt-level = "z"  # Optimize for size.
 lto = true
 codegen-units = 1

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ it provides you with following API:
 - put the state for the given key
 - delete the state for the given key
 - subscribe to the updates for the given key
+- unsubscribe from the updated for the given key
 
 Note that nkv supports keyspace, more info you can find [here](./docs/KEYSPACE.md). 
 

--- a/docs/CLIENT_SERVER_PROTOCOL.md
+++ b/docs/CLIENT_SERVER_PROTOCOL.md
@@ -1,0 +1,75 @@
+# How does clients communicate with `nkv` server?
+
+#### Request structure
+
+When using network over the socket, server accepts command in with following pattern
+
+```
++--------------+-----------------+----------------+----------+-------------+
+| COMMAND: str | REQUEST-ID: str | CLIENT-ID: str | KEY: str | (DATA): str |
++--------------+-----------------+----------------+----------+-------------+
+```
+
+*Note:* if you are using nkv to communicate between threads in your Rust application,
+you will use channels to do so. Checkout NkvCore [source](../src/nkv.rs) for more information.
+
+*Important:* requests are valid UTF-8 strings and are delimited by new line
+
+COMMAND, REQUEST-ID, CLIENT-ID and KEY are valid UTF-8 characters, separated by space.
+That said all four of them **can't contain space symbols**, KEY supports [keyspace](./KEYSPACE.md)
+
+CLIENT-ID is a convinient way to log requests from multiple clients in one place. Granted, REQUEST-ID
+is unique, but with CLIENT-ID it's easier to sort through request coming from a particular client.
+
+Supported commands are: PUT, GET, DEL, SUB, UNSUB.
+For more information commands see [this](../README.md) section "What is it for"
+
+DATA section is used only in PUT command. It is base64-encoded string
+
+REQUEST-ID for SUB command is also used to terminate that subscription via UNSUB command.
+
+For client implementation reference in Rust see [this](../src/lib.rs) struct NkvClient.
+
+#### Example of reqests:
+
+Below are examples of requests in string representation, without their length
+
+```
+PUT request-id-1 client-id-1 FOO BAR
+
+GET request-id-2 client-id-1 FOO
+
+SUB request-id-3 client-id-1 FOO
+
+UNSUB request-id-3 client-id-1 FOO
+
+DEL request-id-4 client-id-1 FOO
+```
+
+#### Response structure:
+Responses follow simple structure as well
+
+```
+REQUEST-ID (OK|FAILED) (DATA)
+```
+
+DATA are space separated base46-encoded optional strings
+
+
+#### Notifications structure:
+
+Main feature of nkv is sending notifications when the value is changed. Idea is to keep the same channel you use to communicate with
+server to send communications through it (note that nkv is built in a way, where you can choose communication channel, unix socket, tcp
+socket, channels, etc. but you might need to implement interfaces to do so). For more information how it all works under the hood check
+out [this](./DESIGN.md) doc. For the scope of this document we focus purely on protocol you need to communicate with nkv. So the messages
+that you recieve from notifications following this structure:
+
+```
+(HELLO|UPDATE|CLOSE|NOTFOUND) KEY DATA
+```
+
+First literal is message type: HELLO and NOTFOUND end on that.
+They indicate established connection or notifying client that there is no such subscription.
+
+CLOSE message is followed by KEY, which tells the client that certain notifier has been closed.
+UPDATE one contains KEY and DATA, latter is base64-encoded value

--- a/src/client/main.rs
+++ b/src/client/main.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::io::{self, Write};
 
-use nkv::nkv::Message;
+use nkv::request_msg::Message;
 use nkv::NkvClient;
 use std::time::Instant;
 
@@ -50,7 +50,7 @@ async fn main() {
                         let start = Instant::now();
                         let resp = client.put(_key.to_string(), boxed_bytes).await.unwrap();
                         let elapsed = start.elapsed();
-                        println!("Request took: {:.2?}\n{}", elapsed, resp);
+                        println!("Request took: {:.2?}\n{:?}", elapsed, resp);
                     } else {
                         println!("PUT requires a key and a value");
                     }
@@ -60,7 +60,7 @@ async fn main() {
                         let start = Instant::now();
                         let resp = client.get(_key.to_string()).await.unwrap();
                         let elapsed = start.elapsed();
-                        println!("Request took: {:.2?}\n{}", elapsed, resp);
+                        println!("Request took: {:.2?}\n{:?}", elapsed, resp);
                     } else {
                         println!("GET requires a key");
                     }
@@ -70,7 +70,7 @@ async fn main() {
                         let start = Instant::now();
                         let resp = client.delete(_key.to_string()).await.unwrap();
                         let elapsed = start.elapsed();
-                        println!("Request took: {:.2?}\n{}", elapsed, resp);
+                        println!("Request took: {:.2?}\n{:?}", elapsed, resp);
                     } else {
                         println!("DELETE requires a key");
                     }
@@ -83,7 +83,7 @@ async fn main() {
                             .await
                             .unwrap();
                         let elapsed = start.elapsed();
-                        println!("Request took: {:.2?}\n{}", elapsed, resp);
+                        println!("Request took: {:.2?}\n{:?}", elapsed, resp);
                     } else {
                         println!("SUBSCRIBE requires a key");
                     }
@@ -93,7 +93,7 @@ async fn main() {
                         let start = Instant::now();
                         let resp = client.unsubscribe(key.to_string()).await.unwrap();
                         let elapsed = start.elapsed();
-                        println!("Request took: {:.2?}\n{}", elapsed, resp);
+                        println!("Request took: {:.2?}\n{:?}", elapsed, resp);
                     } else {
                         println!("SUBSCRIBE requires a key");
                     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,8 @@ pub enum NotifierError {
     FailedToWriteMessage(tokio::io::Error),
     FailedToFlushMessage(tokio::io::Error),
     IoError(std::io::Error),
-    SubscribtionNotFound,
+
+    SubscriptionNotFound,
 }
 
 impl fmt::Display for NotifierError {
@@ -18,7 +19,7 @@ impl fmt::Display for NotifierError {
             NotifierError::FailedToWriteMessage(e) => write!(f, "Failed to Write Message: {}", e),
             NotifierError::FailedToFlushMessage(e) => write!(f, "Failed to Flush Message: {}", e),
             NotifierError::IoError(e) => write!(f, "IoError: {}", e),
-            NotifierError::SubscribtionNotFound => write!(f, "Subscription not found"),
+            NotifierError::SubscriptionNotFound => write!(f, "Subscription not found"),
         }
     }
 }
@@ -29,7 +30,7 @@ impl std::error::Error for NotifierError {
             NotifierError::FailedToWriteMessage(e) => Some(e),
             NotifierError::FailedToFlushMessage(e) => Some(e),
             NotifierError::IoError(e) => Some(e),
-            NotifierError::SubscribtionNotFound => None,
+            NotifierError::SubscriptionNotFound => None,
         }
     }
 }
@@ -39,17 +40,6 @@ pub enum NotifyKeyValueError {
     NotFound,
     NotificationError(NotificationError),
     IoError(std::io::Error),
-}
-
-impl NotifyKeyValueError {
-    pub fn to_http_status(&self) -> http::StatusCode {
-        match self {
-            NotifyKeyValueError::NotFound => http::StatusCode::NOT_FOUND,
-            NotifyKeyValueError::NoError => http::StatusCode::OK,
-            NotifyKeyValueError::NotificationError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
-            NotifyKeyValueError::IoError(_) => http::StatusCode::INTERNAL_SERVER_ERROR,
-        }
-    }
 }
 
 impl From<std::io::Error> for NotifierError {
@@ -91,3 +81,24 @@ impl std::error::Error for NotifyKeyValueError {
         }
     }
 }
+
+#[derive(Debug)]
+pub enum SerializingError {
+    Missing(String),
+    UnknownCommand,
+    InvalidInput,
+    ParseError,
+}
+
+impl fmt::Display for SerializingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Missing(what) => write!(f, "Missing {}", what),
+            Self::UnknownCommand => write!(f, "Unknown command"),
+            Self::InvalidInput => write!(f, "Invalid input"),
+            Self::ParseError => write!(f, "Failed to parse base64"),
+        }
+    }
+}
+
+impl std::error::Error for SerializingError {}

--- a/src/nkv.rs
+++ b/src/nkv.rs
@@ -13,33 +13,11 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::errors::NotifyKeyValueError;
+use crate::request_msg::Message;
 use crate::traits::StorageEngine;
 use crate::trie::{Trie, TrieNode};
-use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, Mutex};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub enum Message {
-    Hello,
-    Update { key: String, value: Box<[u8]> },
-    Close { key: String },
-    NotFound,
-}
-
-impl fmt::Display for Message {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Hello => write!(f, "Hello")?,
-            Self::Update { key, value } => match String::from_utf8(value.to_vec()) {
-                Ok(string) => write!(f, " - {} : {}\n", key, string)?,
-                Err(_) => write!(f, " - {} : {:?}\n", key, value)?,
-            },
-            Self::Close { key } => write!(f, "{}: Close", key)?,
-            Self::NotFound => write!(f, "Not Found")?,
-        }
-        Ok(())
-    }
-}
 #[derive(Debug)]
 pub enum NotificationError {
     AlreadySubscribed(String),

--- a/src/request_msg.rs
+++ b/src/request_msg.rs
@@ -3,26 +3,27 @@
 // This file contains common messages which are
 // used between NkvClient and Server
 
-use http::StatusCode;
-use serde::{Deserialize, Serialize};
+use base64::Engine;
 use std::fmt;
+use std::str;
+use std::str::FromStr;
 
-#[derive(Debug, Deserialize, Serialize)]
+use crate::errors::SerializingError;
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct BaseMessage {
     pub id: String,
     pub key: String,
     pub client_uuid: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PutMessage {
-    #[serde(flatten)]
     pub base: BaseMessage,
     pub value: Box<[u8]>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(tag = "type")]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ServerRequest {
     Put(PutMessage),
     Get(BaseMessage),
@@ -31,51 +32,241 @@ pub enum ServerRequest {
     Unsubscribe(BaseMessage),
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+// Since the protocol is valid UTF-8 String, we use standard Rust traits
+// to convert from and to String, so that one could easily print requests
+// or log them
+impl fmt::Display for ServerRequest {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Put(PutMessage { base, value }) => {
+                // note: use same engine in decode as well
+                let engine = base64::engine::general_purpose::STANDARD;
+                let value = engine.encode(value);
+                write!(
+                    f,
+                    "PUT {} {} {} {}",
+                    base.id, base.client_uuid, base.key, value
+                )
+            }
+            Self::Get(BaseMessage {
+                id,
+                key,
+                client_uuid,
+            }) => write!(f, "GET {} {} {}", id, client_uuid, key),
+            Self::Delete(BaseMessage {
+                id,
+                key,
+                client_uuid,
+            }) => write!(f, "DEL {} {} {}", id, client_uuid, key),
+            Self::Subscribe(BaseMessage {
+                id,
+                key,
+                client_uuid,
+            }) => write!(f, "SUB {} {} {}", id, client_uuid, key),
+            Self::Unsubscribe(BaseMessage {
+                id,
+                key,
+                client_uuid,
+            }) => write!(f, "UNSUB {} {} {}", id, client_uuid, key),
+        }
+    }
+}
+
+// Since the protocol is valid UTF-8 String, we use standard Rust traits
+// to convert from and to String, so that one could easily print requests
+// or log them
+impl FromStr for ServerRequest {
+    type Err = SerializingError;
+
+    fn from_str(input_str: &str) -> Result<Self, Self::Err> {
+        let mut parts = input_str.splitn(5, ' ');
+
+        let request = parts
+            .next()
+            .ok_or(SerializingError::Missing("command".to_string()))?;
+        let id = parts
+            .next()
+            .ok_or(SerializingError::Missing("id".to_string()))?
+            .to_string();
+        let client_uuid = parts
+            .next()
+            .ok_or(SerializingError::Missing("client-uuid".to_string()))?
+            .to_string();
+        let key = parts
+            .next()
+            .ok_or(SerializingError::Missing("key".to_string()))?
+            .to_string();
+
+        match request {
+            "PUT" => {
+                let value = parts
+                    .next()
+                    .ok_or(SerializingError::Missing("value".to_string()))?
+                    .to_string();
+
+                // note: use same engine in encode as well
+                let engine = base64::engine::general_purpose::STANDARD;
+                let value = if value.is_empty() {
+                    Vec::new()
+                } else {
+                    engine.decode(value).expect("Failed to decode Base64")
+                };
+                Ok(Self::Put(PutMessage {
+                    base: BaseMessage {
+                        id,
+                        client_uuid,
+                        key,
+                    },
+                    value: value.into(),
+                }))
+            }
+            "GET" => Ok(Self::Get(BaseMessage {
+                id,
+                client_uuid,
+                key,
+            })),
+            "DEL" => Ok(Self::Delete(BaseMessage {
+                id,
+                client_uuid,
+                key,
+            })),
+            "SUB" => Ok(Self::Subscribe(BaseMessage {
+                id,
+                client_uuid,
+                key,
+            })),
+            "UNSUB" => Ok(Self::Unsubscribe(BaseMessage {
+                id,
+                client_uuid,
+                key,
+            })),
+            _ => Err(SerializingError::UnknownCommand),
+        }
+    }
+}
+
 pub struct BaseResp {
     pub id: String,
-
-    #[serde(with = "http_serde::status_code")]
-    pub status: StatusCode,
-    pub message: String,
+    pub status: bool, // true --successful false -- failed
 }
 
 impl fmt::Display for BaseResp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "Id: {}\nStatus: {}\nMessage: {}",
-            self.id, self.status, self.message
-        )
+        write!(f, "{} ", self.id)?;
+        match &self.status {
+            true => write!(f, "OK"),
+            false => write!(f, "FAILED"),
+        }
+    }
+}
+
+impl fmt::Debug for BaseResp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} ", self.id)?;
+        match &self.status {
+            true => write!(f, "OK"),
+            false => write!(f, "FAILED"),
+        }
+    }
+}
+
+impl FromStr for BaseResp {
+    type Err = SerializingError;
+
+    fn from_str(input_str: &str) -> Result<Self, Self::Err> {
+        let mut parts = input_str.splitn(3, ' ');
+        let id = parts
+            .next()
+            .ok_or(SerializingError::Missing("id".to_string()))?
+            .to_string();
+        let status = parts
+            .next()
+            .ok_or(SerializingError::Missing("status".to_string()))?
+            .to_string();
+        let status = match status.as_str() {
+            "OK" => true,
+            "FAILED" => false,
+            _ => return Err(SerializingError::UnknownCommand),
+        };
+
+        Ok(Self { id, status })
     }
 }
 
 impl PartialEq for BaseResp {
     fn eq(&self, other: &Self) -> bool {
         // Ignoring id intentionally
-        self.status == other.status && self.message == other.message
+        self.status == other.status
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
 pub struct DataResp {
-    #[serde(flatten)]
     pub base: BaseResp,
     pub data: Vec<Vec<u8>>,
 }
 
 impl fmt::Display for DataResp {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}\n", self.base)?;
-        write!(f, "Data:\n")?;
+        write!(f, "{}", self.base)?;
+
+        for el in self.data.iter() {
+            // note: use same engine in decode as well
+            let engine = base64::engine::general_purpose::STANDARD;
+            let value = engine.encode(el);
+            write!(f, " {}", value)?
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for DataResp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.base)?;
 
         for el in self.data.iter() {
             match String::from_utf8(el.clone()) {
-                Ok(string) => write!(f, " - {}\n", string)?,
-                Err(_) => write!(f, " - {:?}\n", el)?,
+                Ok(s) => write!(f, " {}", s)?,
+                Err(_) => write!(f, " {:?}", el)?,
             }
         }
         Ok(())
+    }
+}
+
+impl FromStr for DataResp {
+    type Err = SerializingError;
+
+    fn from_str(input_str: &str) -> Result<Self, Self::Err> {
+        let mut parts = input_str.split_whitespace();
+
+        // Parse the BaseResp part
+        let id = parts
+            .next()
+            .ok_or(SerializingError::Missing("id".to_string()))?
+            .to_string();
+
+        let status_str = parts
+            .next()
+            .ok_or(SerializingError::Missing("status".to_string()))?
+            .to_string();
+        let status = match status_str.as_str() {
+            "OK" => true,
+            "FAILED" => false,
+            _ => return Err(SerializingError::UnknownCommand),
+        };
+
+        let base = BaseResp { id, status };
+
+        let data = parts
+            .map(|encoded| {
+                let engine = base64::engine::general_purpose::STANDARD;
+                engine
+                    .decode(encoded)
+                    .map_err(|_| SerializingError::ParseError)
+            })
+            .collect::<Result<Vec<Vec<u8>>, _>>()?;
+
+        Ok(Self { base, data })
     }
 }
 
@@ -85,21 +276,16 @@ impl PartialEq for DataResp {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
 pub enum ServerResponse {
     Base(BaseResp),
-    Get(DataResp),
-    Put(DataResp),
-    Sub(DataResp),
+    Data(DataResp),
 }
 
 impl PartialEq for ServerResponse {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Base(lhs), Self::Base(rhs)) => lhs == rhs,
-            (Self::Get(lhs), Self::Get(rhs)) => lhs == rhs,
-            (Self::Put(lhs), Self::Put(rhs)) => lhs == rhs,
-            (Self::Sub(lhs), Self::Sub(rhs)) => lhs == rhs,
+            (Self::Data(lhs), Self::Data(rhs)) => lhs == rhs,
             _ => false,
         }
     }
@@ -108,10 +294,348 @@ impl PartialEq for ServerResponse {
 impl fmt::Display for ServerResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Base(resp) => write!(f, "{}", resp),
-            Self::Get(resp) => write!(f, "{}", resp),
-            Self::Put(resp) => write!(f, "{}", resp),
-            Self::Sub(resp) => write!(f, "{}", resp),
+            Self::Base(resp) => {
+                write!(f, "{}", resp)
+            }
+            Self::Data(resp) => {
+                write!(f, "{}", resp)
+            }
         }
+    }
+}
+
+impl fmt::Debug for ServerResponse {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Base(resp) => {
+                write!(f, "{:?}", resp)
+            }
+            Self::Data(resp) => {
+                write!(f, "{:?}", resp)
+            }
+        }
+    }
+}
+
+impl FromStr for ServerResponse {
+    type Err = SerializingError;
+
+    fn from_str(input_str: &str) -> Result<Self, Self::Err> {
+        match input_str.split_whitespace().count() {
+            2 => {
+                let base_resp: BaseResp = input_str.parse()?;
+                Ok(ServerResponse::Base(base_resp))
+            }
+            3 => {
+                let data_resp: DataResp = input_str.parse()?;
+                Ok(ServerResponse::Data(data_resp))
+            }
+            _ => Err(SerializingError::UnknownCommand),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Message {
+    Hello,
+    Update { key: String, value: Box<[u8]> },
+    Close { key: String },
+    NotFound,
+}
+
+impl fmt::Display for Message {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Hello => write!(f, "HELLO"),
+            Self::Update { key, value } => {
+                let engine = base64::engine::general_purpose::STANDARD;
+                let value = engine.encode(&value);
+                write!(f, "UPDATE {} {}", key, value)
+            }
+            Self::Close { key } => write!(f, "CLOSE {}", key),
+            Self::NotFound => write!(f, "NOTFOUND"),
+        }
+    }
+}
+
+impl FromStr for Message {
+    type Err = SerializingError;
+
+    fn from_str(input_str: &str) -> Result<Self, Self::Err> {
+        let mut parts = input_str.split_whitespace();
+
+        let msg_type = parts
+            .next()
+            .ok_or(SerializingError::Missing("type".to_string()))?
+            .to_string();
+
+        match msg_type.as_str() {
+            "HELLO" => Ok(Self::Hello),
+            "UPDATE" => {
+                let key = parts
+                    .next()
+                    .ok_or(SerializingError::Missing("key".to_string()))?
+                    .to_string();
+                let value = parts
+                    .next()
+                    .ok_or(SerializingError::Missing("value".to_string()))?
+                    .to_string();
+                let engine = base64::engine::general_purpose::STANDARD;
+                let value = engine.decode(value).expect("Failed to decode Base64");
+
+                Ok(Self::Update {
+                    key,
+                    value: value.into(),
+                })
+            }
+            "CLOSE" => {
+                let key = parts
+                    .next()
+                    .ok_or(SerializingError::Missing("key".to_string()))?
+                    .to_string();
+
+                Ok(Self::Close { key })
+            }
+            "NOTFOUND" => Ok(Self::NotFound),
+            _ => Err(SerializingError::UnknownCommand),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_server_request_from_str() {
+        let id = "ID".to_string();
+        let client_uuid = "CLIENT-UUID".to_string();
+        let key = "KEY".to_string();
+
+        let data: Vec<u8> = vec![1, 0, 13, 12];
+        let engine = base64::engine::general_purpose::STANDARD;
+        let value = engine.encode(&data);
+        let req = format!("PUT {} {} {} {}", id, client_uuid, key, value);
+        let result = ServerRequest::from_str(&req).unwrap();
+        assert_eq!(
+            result,
+            ServerRequest::Put(PutMessage {
+                base: BaseMessage {
+                    id: id.clone(),
+                    key: key.clone(),
+                    client_uuid: client_uuid.clone(),
+                },
+                value: data.into(),
+            })
+        );
+
+        let req = format!("GET {} {} {}", id, client_uuid, key);
+        let result = ServerRequest::from_str(&req).unwrap();
+        assert_eq!(
+            result,
+            ServerRequest::Get(BaseMessage {
+                id: id.clone(),
+                key: key.clone(),
+                client_uuid: client_uuid.clone(),
+            })
+        );
+
+        let req = format!("DEL {} {} {}", id, client_uuid, key);
+        let result = ServerRequest::from_str(&req).unwrap();
+        assert_eq!(
+            result,
+            ServerRequest::Delete(BaseMessage {
+                id: id.clone(),
+                key: key.clone(),
+                client_uuid: client_uuid.clone(),
+            })
+        );
+
+        let req = format!("SUB {} {} {}", id, client_uuid, key);
+        let result = ServerRequest::from_str(&req).unwrap();
+        assert_eq!(
+            result,
+            ServerRequest::Subscribe(BaseMessage {
+                id: id.clone(),
+                key: key.clone(),
+                client_uuid: client_uuid.clone(),
+            })
+        );
+
+        let req = format!("UNSUB {} {} {}", id, client_uuid, key);
+        let result = ServerRequest::from_str(&req).unwrap();
+        assert_eq!(
+            result,
+            ServerRequest::Unsubscribe(BaseMessage {
+                id: id.clone(),
+                key: key.clone(),
+                client_uuid: client_uuid.clone(),
+            })
+        );
+
+        let req = format!("WRONG COMMAND");
+        let result = ServerRequest::from_str(&req);
+        assert_eq!(result.is_err(), true);
+
+        let req = format!("GET");
+        let result = ServerRequest::from_str(&req);
+        assert_eq!(result.is_err(), true);
+
+        let req = format!("GET {}", id);
+        let result = ServerRequest::from_str(&req);
+        assert_eq!(result.is_err(), true);
+
+        let req = format!("GET {} {}", id, client_uuid);
+        let result = ServerRequest::from_str(&req);
+        assert_eq!(result.is_err(), true);
+    }
+
+    #[test]
+    fn test_server_request_to_str() {
+        let id = "ID".to_string();
+        let client_uuid = "CLIENT-UUID".to_string();
+        let key = "KEY".to_string();
+
+        let data: Vec<u8> = vec![1, 0, 13, 12];
+        let req = ServerRequest::Put(PutMessage {
+            base: BaseMessage {
+                id: id.clone(),
+                key: key.clone(),
+                client_uuid: client_uuid.clone(),
+            },
+            value: data.clone().into(),
+        });
+        let engine = base64::engine::general_purpose::STANDARD;
+        let value = engine.encode(data);
+        let expected = format!("PUT {} {} {} {}", id, client_uuid, key, value);
+        assert_eq!(req.to_string(), expected);
+
+        let req = ServerRequest::Get(BaseMessage {
+            id: id.clone(),
+            key: key.clone(),
+            client_uuid: client_uuid.clone(),
+        });
+        let expected = format!("GET {} {} {}", id, client_uuid, key);
+        assert_eq!(req.to_string(), expected);
+
+        let req = ServerRequest::Delete(BaseMessage {
+            id: id.clone(),
+            key: key.clone(),
+            client_uuid: client_uuid.clone(),
+        });
+        let expected = format!("DEL {} {} {}", id, client_uuid, key);
+        assert_eq!(req.to_string(), expected);
+
+        let req = ServerRequest::Subscribe(BaseMessage {
+            id: id.clone(),
+            key: key.clone(),
+            client_uuid: client_uuid.clone(),
+        });
+        let expected = format!("SUB {} {} {}", id, client_uuid, key);
+        assert_eq!(req.to_string(), expected);
+
+        let req = ServerRequest::Unsubscribe(BaseMessage {
+            id: id.clone(),
+            key: key.clone(),
+            client_uuid: client_uuid.clone(),
+        });
+        let expected = format!("UNSUB {} {} {}", id, client_uuid, key);
+        assert_eq!(req.to_string(), expected);
+    }
+
+    #[test]
+    fn test_server_response_to_str() {
+        let id = "1".to_string();
+        let resp = ServerResponse::Base(BaseResp {
+            id: id.clone(),
+            status: true,
+        });
+        assert_eq!(resp.to_string(), format!("{} OK", &id));
+
+        let data: Vec<Vec<u8>> = vec![vec![1, 2, 3, 4]];
+        let resp = ServerResponse::Data(DataResp {
+            base: BaseResp {
+                id: id.clone(),
+                status: false,
+            },
+            data: data.clone(),
+        });
+        let engine = base64::engine::general_purpose::STANDARD;
+        let value = engine.encode(&data[0]);
+        assert_eq!(resp.to_string(), format!("{} FAILED {}", id, value))
+    }
+
+    #[test]
+    fn test_server_response_from_str() {
+        let id = "1".to_string();
+        let expected = ServerResponse::Base(BaseResp {
+            id: id.clone(),
+            status: true,
+        });
+        let got: ServerResponse = format!("{} OK", &id).parse().unwrap();
+        assert_eq!(got, expected);
+
+        let data: Vec<Vec<u8>> = vec![vec![1, 2, 3, 4]];
+        let engine = base64::engine::general_purpose::STANDARD;
+        let value = engine.encode(&data[0]);
+        let got: ServerResponse = format!("{} FAILED {}", id, value).parse().unwrap();
+        let expected = ServerResponse::Data(DataResp {
+            base: BaseResp {
+                id: id.clone(),
+                status: false,
+            },
+            data: data.clone(),
+        });
+        assert_eq!(expected, got);
+    }
+
+    #[test]
+    fn test_message_to_str() {
+        assert_eq!(Message::Hello.to_string(), format!("HELLO"));
+
+        assert_eq!(Message::NotFound.to_string(), format!("NOTFOUND"));
+
+        let key = "MYAWESOMEKEY".to_string();
+        assert_eq!(
+            Message::Close { key: key.clone() }.to_string(),
+            format!("CLOSE {}", key.clone())
+        );
+
+        let data: Vec<u8> = vec![1, 0, 13, 12];
+        let engine = base64::engine::general_purpose::STANDARD;
+        let value = engine.encode(&data);
+        assert_eq!(
+            Message::Update {
+                key: key.clone(),
+                value: data.into()
+            }
+            .to_string(),
+            format!("UPDATE {} {}", key, value)
+        )
+    }
+
+    #[test]
+    fn test_message_from_str() {
+        let got: Message = "HELLO".parse().unwrap();
+        assert_eq!(got, Message::Hello);
+
+        let got: Message = "NOTFOUND".parse().unwrap();
+        assert_eq!(got, Message::NotFound);
+
+        let key = "MYAWESOMEKEY".to_string();
+        let got: Message = format!("CLOSE {}", key.clone()).parse().unwrap();
+        assert_eq!(got, Message::Close { key: key.clone() });
+
+        let data: Vec<u8> = vec![1, 0, 13, 12];
+        let engine = base64::engine::general_purpose::STANDARD;
+        let value = engine.encode(&data);
+        let got: Message = format!("UPDATE {} {}", key, value).parse().unwrap();
+        assert_eq!(
+            got,
+            Message::Update {
+                key: key.clone(),
+                value: data.into()
+            }
+        )
     }
 }


### PR DESCRIPTION
In order to be able to create clients in multiple languages, we need a universal (de-)serializer, using JSON won't work, because Rust and Golang marshal it differently, so there will be hustle around name convention.

In addition, using binary mashalization will reduce network bandwidth, note that server deserialize message before storing it.